### PR TITLE
Add script for sanitizing data

### DIFF
--- a/scripts/data_bleach.py
+++ b/scripts/data_bleach.py
@@ -1,0 +1,64 @@
+import json
+import sys
+
+
+PUBLIC_FIELDS = [x.split('.') for x in [
+    "aliquot.experimental_strategy",
+    "aliquot.node_id",
+    "aliquot.submitter_id",
+    "case.node_id",
+    "case.project_id",
+    "case.submitter_id",
+    "read_group.sequencing_center",
+    "sample.biospecimen_type",
+    "sample.composition",
+    "sample.node_id"]]
+
+
+def error(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+    exit(1)
+
+
+def is_protected_field(key, context):
+    return not any([context + [key] == field for field in PUBLIC_FIELDS])
+
+
+def recursive_clear(d, context=None):
+    """
+    clear the values of a dictionary unless the value is another dictionary
+    in which case recurse
+    """
+    if context is None:
+        context = []
+
+    for key in d:
+        val = d[key]
+        if type(val) == dict:
+            recursive_clear(val, context=context + [key])
+        else:
+            if is_protected_field(key, context):
+                d[key] = ''
+
+
+def sanitize_bundle(bundle):
+    metadata = bundle['data_bundle']['user_metadata']
+    recursive_clear(metadata)
+    metadata['program'] = 'gtex'
+    metadata['project'] = 'GTEx-v7'
+
+
+def main(argv):
+    if len(argv) != 3:
+        error('Usage: python3 data_bleach.py INPUT.json OUTPUT.json')
+    with open(argv[1], 'r') as fp:
+        data = json.load(fp)
+    for bundle in data:
+        sanitize_bundle(bundle)
+    with open(argv[2], 'w') as fp:
+        json.dump(data, fp)
+
+
+if __name__ == '__main__':
+    main(sys.argv)
+


### PR DESCRIPTION
This cleans up gtex data by clearing fields not specifically whitelisted. Also it adds project and program to the user_metadata.

This script is designed only for gtex data, but can be improved, expanded at a later point.