### PR TITLE
Assign a default value when no demographics are available

### DIFF
--- a/newt/transform/gen3standard.py
+++ b/newt/transform/gen3standard.py
@@ -68,6 +68,7 @@ class Bundle(dict):
             # Go to the list of entries we want to look in
             entries = metadata_source[source_field_name]
             # Look for the entry that links to our item
+            linked_field_dict = {}
             for key in entries:
                 entry = entries[key]
                 if entry['link_fields'][link_name] == existing_id:


### PR DESCRIPTION
This should allow COPDGene to be transformed and covers the case when demographic metadata have not been provided.

Without this default value, the `linked_field_dict` would be accessed before being initialized.

@jessebrennan 